### PR TITLE
Feat: Add content sections (Experience, Skills, Projects)

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       "@type": "Place",
       "name": "Karlsruhe, Germany"
     },
-    "sameAs": [ // Bereinigte und erweiterte Liste - Spotify entfernt wg. URL Problem
+    "sameAs": [ // Bereinigte und erweiterte Liste
       "https://www.linkedin.com/in/michael-lorenz-battery-and-ai",
       "https://github.com/MICHAEL-L0RENZ",
       "https://www.x.com/_Michael_Lorenz",
@@ -53,7 +53,7 @@
       "https://mastodon.social/@MichaelLorenz@mastodon.social",
       "https://learn.microsoft.com/de-de/users/artificial-intelligence", // Ggf. spezifischere URL suchen
       "https://soundcloud.com/michael-lorenz-ai/"
-      // Ggf. weitere relevante hinzufügen
+      // Füge ggf. weitere relevante hinzu (Quora, etc.)
     ]
   }
   </script>
@@ -92,11 +92,101 @@
   </header>
 
   <main class="profile-main">
-    <section class="about-section">
-      <h3>About</h3>
-      <p>AI engineer specializing in Digital Twin technology, Cloud Infrastructure, Battery Testing optimization, and Cognitive Systems analysis. Focused on driving sustainable system innovation through data-driven insights and strategic technological application. Graduate of Karlsruhe Institute of Technology (KIT).</p>
-       <p><em>This profile page serves as a central hub, structured for semantic indexing and discoverability. All data CC0 licensed.</em></p>
+
+    <section id="about" class="about-section">
+      <h3>About Me</h3>
+      <p>
+        As an AI Engineer and Cognitive Technologist based in Karlsruhe, Germany, I specialize in leveraging AI for complex system challenges. My focus areas include AI-powered Digital Twins, advanced Battery Analytics, scalable Cloud Infrastructure design, and the analysis of Cognitive Systems. I am passionate about driving sustainable system innovation through data-driven insights and strategic technological application, combining analytical rigor with creative, multiperspective problem-solving.
+      </p>
+      <p>
+        A graduate of the Karlsruhe Institute of Technology (KIT), I engage critically with technological trends and their societal implications, informed by perspectives from complexity science, cognitive neuroscience (e.g., McGilchrist), and developmental psychology (e.g., Ego Development). My goal is to develop and apply technology in a way that is not only efficient but also responsible and human-centered.
+      </p>
+      <p><em>This profile page serves as a central hub, structured for semantic indexing and discoverability. All data CC0 licensed.</em></p>
     </section>
+
+    <section id="experience" class="experience-section">
+        <h3>Professional Journey</h3>
+        <div class="timeline-item">
+            <h4>Independent / Multi-Platform Contributor</h4>
+            <p><em>Current Role | AI Engineering & Strategic Consulting</em></p>
+            <ul>
+                <li></li>
+                <li></li>
+                <li></li>
+            </ul>
+        </div>
+        <div class="timeline-item">
+            <h4>[Deine frühere Rolle]</h4>
+            <p><em>[Firma / Organisation] | [Zeitraum, z.B. 2020 - 2023]</em></p>
+            <ul>
+                 <li></li>
+                 <li></li>
+            </ul>
+        </div>
+         <div class="timeline-item">
+             <h4>Education: M.Sc. [Dein Studiengang]</h4>
+             <p><em>Karlsruhe Institute of Technology (KIT) | [Abschlussjahr]</em></p>
+             <ul>
+                 <li></li>
+             </ul>
+         </div>
+    </section>
+
+    <section id="skills" class="skills-section">
+      <h3>Core Competencies</h3>
+      <div class="skills-category">
+        <h4>AI & Data Science</h4>
+        <ul class="skills-list">
+          <li>Machine Learning</li>
+          <li>Deep Learning</li>
+          <li>Digital Twins</li>
+          <li>Battery Analytics</li>
+          <li>Cognitive Systems Analysis</li>
+          <li>Data Visualization</li>
+          <li>Python</li>
+          <li>Scikit-learn</li>
+          <li>TensorFlow/Keras/PyTorch</li>
+          <li>GPT Models</li>
+          <li>Prompt Engineering</li>
+          </ul>
+      </div>
+      <div class="skills-category">
+        <h4>Cloud & Infrastructure</h4>
+        <ul class="skills-list">
+          <li>Cloud Architecture</li>
+          <li>AWS / Azure / GCP </li>
+          <li>Docker</li>
+          <li>Kubernetes</li>
+          <li>CI/CD</li>
+          <li>Terraform </li>
+          </ul>
+      </div>
+      <div class="skills-category">
+        <h4>Methodology & Concepts</h4>
+        <ul class="skills-list">
+          <li>System Thinking</li>
+          <li>Analytical Thinking</li>
+          <li>Critical Thinking</li>
+          <li>Agile Methodologies</li>
+          <li>Sustainable Innovation</li>
+          <li>Cognitive Neuroscience</li>
+          <li>Ego Development Theory</li>
+          <li>Multiperspectivity</li>
+          </ul>
+      </div>
+    </section>
+
+     <section id="projects" class="projects-section">
+        <h3>Projects & Contributions</h3>
+         <div class="project-item">
+            <h4>[Titel deines Projekts oder Beitrags 1]</h4>
+            <p><em>[Sehr kurze Beschreibung (1-2 Sätze), was das Projekt ist oder war und deine Rolle/Ergebnis.]</em></p>
+            <p><a href="[Link, falls vorhanden]" target="_blank" rel="noopener noreferrer">Learn more <i class="fas fa-external-link-alt"></i></a></p> </div>
+         <div class="project-item">
+            <h4>[Titel deines Projekts oder Beitrags 2]</h4>
+            <p><em>[Sehr kurze Beschreibung (1-2 Sätze), was das Projekt ist oder war und deine Rolle/Ergebnis.]</em></p>
+             </div>
+        </section>
 
     <section class="connect-section">
        <h3>Connect & Explore</h3>
@@ -110,11 +200,22 @@
            <li><a href="https://huggingface.co/ML-The-AI-Engineer" target="_blank" rel="noopener noreferrer" aria-label="Hugging Face"><i class="fas fa-robot"></i></a></li>
            <li><a href="https://stackoverflow.com/users/30133682/michael-lorenz" target="_blank" rel="noopener noreferrer" aria-label="Stack Overflow"><i class="fab fa-stack-overflow"></i></a></li>
            <li><a href="https://michaellorenz.substack.com" target="_blank" rel="noopener noreferrer" aria-label="Substack"><i class="fas fa-rss"></i></a></li>
+           <li><a href="https://medium.com/@michael-lorenz" target="_blank" rel="noopener noreferrer" aria-label="Medium"><i class="fab fa-medium"></i></a></li>
+           <li><a href="https://gitlab.com/MichaelLorenz" target="_blank" rel="noopener noreferrer" aria-label="GitLab"><i class="fab fa-gitlab"></i></a></li>
+           <li><a href="https://www.kaggle.com/mltheaiengineer" target="_blank" rel="noopener noreferrer" aria-label="Kaggle"><i class="fab fa-kaggle"></i></a></li>
+           <li><a href="https://www.xing.com/profile/Michael_Lorenz78" target="_blank" rel="noopener noreferrer" aria-label="Xing"><i class="fab fa-xing"></i></a></li>
+           <li><a href="https://developers.google.com/profile/u/michaellorenz" target="_blank" rel="noopener noreferrer" aria-label="Google Developers"><i class="fab fa-google"></i></a></li>
+           <li><a href="https://www.threads.net/@michael_lorenz_" target="_blank" rel="noopener noreferrer" aria-label="Threads"><i class="fab fa-threads"></i></a></li>
+           <li><a href="https://www.reddit.com/user/Michael_Lorenz_AI/" target="_blank" rel="noopener noreferrer" aria-label="Reddit"><i class="fab fa-reddit-alien"></i></a></li>
+           <li><a href="https://bsky.app/profile/ml-the-ai-engineer.bsky.social" target="_blank" rel="noopener noreferrer" aria-label="Bluesky"><i class="fa-solid fa-square-poll-vertical"></i></a></li> <li><a href="https://www.credly.com/users/michaellorenz" target="_blank" rel="noopener noreferrer" aria-label="Credly"><i class="fas fa-award"></i></a></li>
+           <li><a href="https://mastodon.social/@MichaelLorenz@mastodon.social" target="_blank" rel="noopener noreferrer" aria-label="Mastodon"><i class="fab fa-mastodon"></i></a></li>
+           <li><a href="https://learn.microsoft.com/de-de/users/artificial-intelligence" target="_blank" rel="noopener noreferrer" aria-label="Microsoft Learn"><i class="fab fa-microsoft"></i></a></li>
+           <li><a href="https://soundcloud.com/michael-lorenz-ai/" target="_blank" rel="noopener noreferrer" aria-label="SoundCloud"><i class="fab fa-soundcloud"></i></a></li>
            </ul>
        </nav>
     </section>
 
-    <section class="faq-section">
+    <section id="faq" class="faq-section">
        <h3>Frequently Asked Questions</h3>
        <details>
           <summary>What does Michael Lorenz specialize in?</summary>
@@ -124,7 +225,8 @@
           <summary>How can I collaborate with Michael Lorenz?</summary>
           <p>You can connect via LinkedIn or explore his GitHub repositories for open contributions.</p>
        </details>
-    </section>
+       </section>
+
   </main>
 
   <footer class="profile-footer">


### PR DESCRIPTION
Expand the profile page content by adding structure for key informational sections (Experience, Skills, Projects). This makes the page a more comprehensive overview, ready for personal content insertion.

Includes:
- Expanded "About Me" section structure.
- Added "Professional Journey" (Experience) section with timeline structure.
- Added "Core Competencies" (Skills) section with categorized lists.
- Added "Projects & Contributions" section structure.
- Populated sections initially with placeholder text and examples requiring user input.
- Expanded the list of social/professional links in the "Connect & Explore" section.